### PR TITLE
Purge deprecated function call.

### DIFF
--- a/hintview/Linux/renderOGL.c
+++ b/hintview/Linux/renderOGL.c
@@ -257,7 +257,6 @@ void nativeInit(void)
   printGLString("Version", GL_VERSION);
   printGLString("Vendor", GL_VENDOR);
   printGLString("Renderer", GL_RENDERER);
-  printGLString("Extensions", GL_EXTENSIONS);
 
     /* Create the vertex array object (VAO) */
   glGenVertexArrays(1, &VertexArrayID);


### PR DESCRIPTION
See https://github.com/kbranigan/Simple-OpenGL-Image-Library/issues/8 for details. (HintView uses GL 4.6 at this time, so there's no big concern about compatibility with GL < 3.0.)