### PR TITLE
Rpmbuild packaging

### DIFF
--- a/hintview/Linux/Makefile
+++ b/hintview/Linux/Makefile
@@ -81,8 +81,8 @@ MANDIR=/usr/local/man
 
 install: hintview
 	strip hintview
-	install -t $(BINDIR) --mode=755 hintview
-	install -t $(MANDIR)/man1 --mode=644 hintview.1
+	install -t $(DESTDIR)$(BINDIR) --mode=755 hintview
+	install -t $(DESTDIR)$(MANDIR)/man1 --mode=644 hintview.1
 
 .PHONY: clean
 clean:

--- a/hintview/Linux/Makefile
+++ b/hintview/Linux/Makefile
@@ -81,6 +81,8 @@ MANDIR=/usr/local/man
 
 install: hintview
 	strip hintview
+	install -d $(DESTDIR)$(BINDIR)
+	install -d $(DESTDIR)$(MANDIR)/man1
 	install -t $(DESTDIR)$(BINDIR) --mode=755 hintview
 	install -t $(DESTDIR)$(MANDIR)/man1 --mode=644 hintview.1
 

--- a/hintview/Linux/Makefile
+++ b/hintview/Linux/Makefile
@@ -81,10 +81,8 @@ MANDIR=/usr/local/man
 
 install: hintview
 	strip hintview
-	install -d $(DESTDIR)$(BINDIR)
-	install -d $(DESTDIR)$(MANDIR)/man1
-	install -t $(DESTDIR)$(BINDIR) --mode=755 hintview
-	install -t $(DESTDIR)$(MANDIR)/man1 --mode=644 hintview.1
+	install -t $(BINDIR) --mode=755 hintview
+	install -t $(MANDIR)/man1 --mode=644 hintview.1
 
 .PHONY: clean
 clean:

--- a/hintview/Linux/README.md
+++ b/hintview/Linux/README.md
@@ -21,6 +21,9 @@ Without gtk+, the input file must be given on the command line.
 ### hintview.1
 The man page for hintview
 
+### hintview.spec
+Packaging script for use with `rpmbuild` and `debbuild`
+
 ### main.c and main.h
 A short main program
 

--- a/hintview/Linux/hintview.spec
+++ b/hintview/Linux/hintview.spec
@@ -7,8 +7,8 @@ License: GPLv3+
 URL: https://hint.userweb.mwn.de/hint/%{name}.html
 Source0: https://github.com/ruckertm/HINT/eleases/%{name}-%{version}.tar.gz
 
-BuildRequires:
-Requires:
+#BuildRequires:
+#Requires:
 
 %description
 The Hintview program for Linux.
@@ -21,6 +21,7 @@ cd %{name}/Linux
 make
 
 %install
+cd %{name}/Linux
 %make_install
 
 %files

--- a/hintview/Linux/hintview.spec
+++ b/hintview/Linux/hintview.spec
@@ -14,7 +14,7 @@ Requires:
 The Hintview program for Linux.
 
 %prep
-%setup -q
+%autosetup -c
 
 %build
 cd %{name}/Linux

--- a/hintview/Linux/hintview.spec
+++ b/hintview/Linux/hintview.spec
@@ -22,7 +22,12 @@ make
 
 %install
 cd %{name}/Linux
-%make_install
+strip hintview
+%{__rm} -rf %{buildroot}
+%{__install} -d %{buildroot}%{_bindir} \
+	%{buildroot}%{_mandir}/man1
+%{__install} -t %(buildroot}%{_bindir) --mode=755 hintview
+%{__install} -t %(buildroot}%{_mandir)/man1 --mode=644 hintview.1
 
 %files
 %license LICENSE

--- a/hintview/Linux/hintview.spec
+++ b/hintview/Linux/hintview.spec
@@ -1,0 +1,33 @@
+Name: hintview
+Version: 1.3.1
+Release: 1%{?dist}
+Summary: Hintview for Linux
+License: GPLv3+
+
+URL: https://hint.userweb.mwn.de/hint/%{name}.html
+Source0: https://github.com/ruckertm/HINT/eleases/%{name}-%{version}.tar.gz
+
+BuildRequires:
+Requires:
+
+%description
+The Hintview program for Linux.
+
+%prep
+%setup -q
+
+%build
+cd %{name}/Linux
+make
+
+%install
+%make_install
+
+%files
+%license LICENSE
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1
+
+%changelog
+* Fri Sep 29 2023 Andreas Scherer <https://ascherer.github.io>
+- First Hintview package

--- a/hintview/Linux/hintview.spec
+++ b/hintview/Linux/hintview.spec
@@ -30,9 +30,8 @@ strip hintview
 %{__install} -t %{buildroot}%{_mandir}/man1 --mode=644 hintview.1
 
 %files
-%license LICENSE
 %{_bindir}/%{name}
-%{_mandir}/man1/%{name}.1
+%{_mandir}/man1/%{name}.1.gz
 
 %changelog
 * Fri Sep 29 2023 Andreas Scherer <https://ascherer.github.io>

--- a/hintview/Linux/hintview.spec
+++ b/hintview/Linux/hintview.spec
@@ -2,13 +2,23 @@ Name: hintview
 Version: 1.3.1
 Release: 1%{?dist}
 Summary: Hintview for Linux
-License: GPLv3+
+License: GPLv2.1
+Packager: Andreas Scherer <https://ascherer.github.io/>
 
 URL: https://hint.userweb.mwn.de/hint/%{name}.html
 Source0: https://github.com/ruckertm/HINT/eleases/%{name}-%{version}.tar.gz
 
-#BuildRequires:
-#Requires:
+%if "%{_vendor}" == "debbuild"
+BuildRequires: libegl-dev libegl1-mesa-dev libffi-dev
+BuildRequires: libgl-dev libgl1-mesa-dev libgles-dev
+BuildRequires: libglew-dev libglfw3-dev libglu1-mesa-dev
+BuildRequires: libglvnd-core-dev libglvnd-dev libglx-dev
+BuildRequires: libopengl-dev libvulkan-dev libwayland-bin
+BuildRequires: libwayland-dev libxcursor-dev libxext-dev
+BuildRequires: libxfixes-dev libxi-dev libxinerama-dev
+BuildRequires: libxrandr-dev libxrender-dev
+Requires: libglew2.2 libglfw3
+%endif
 
 %description
 The Hintview program for Linux.

--- a/hintview/Linux/hintview.spec
+++ b/hintview/Linux/hintview.spec
@@ -26,8 +26,8 @@ strip hintview
 %{__rm} -rf %{buildroot}
 %{__install} -d %{buildroot}%{_bindir} \
 	%{buildroot}%{_mandir}/man1
-%{__install} -t %(buildroot}%{_bindir) --mode=755 hintview
-%{__install} -t %(buildroot}%{_mandir)/man1 --mode=644 hintview.1
+%{__install} -t %{buildroot}%{_bindir} --mode=755 hintview
+%{__install} -t %{buildroot}%{_mandir}/man1 --mode=644 hintview.1
 
 %files
 %license LICENSE


### PR DESCRIPTION
I use `hintview.spec` (together with `git archive -o hintview-1.3.1.tar.gz HEAD`) to build installable packages with **rpmbuild** and **debbuild**.