### PR TITLE
Add ellipsis in menu after 'Preferences'.

### DIFF
--- a/hintview/Linux/header.c
+++ b/hintview/Linux/header.c
@@ -89,7 +89,7 @@ struct button_def {
   {dark_id, "Dark mode",NULL,"Switch beween dark and light mode (Ctrl+D)", cb_day_night,NULL},
   {reload_id, "Reload file", "view-refresh-symbolic","Reload document (Ctrl+R)", cb_reload,NULL},
   {outline_id, "Outline", "view-list-symbolic","Show Outline (Ctrl+T)", cb_outline,NULL},
-  {pref_id, "Preferences...", "preferences-system-symbolic","Set Preferences (Ctrl+P)", cb_preferences,NULL},
+  {pref_id, "Preferences", "preferences-system-symbolic","Set Preferences (Ctrl+P)", cb_preferences,NULL},
 };
 
 
@@ -237,7 +237,7 @@ create_menu (void)
 
 
   /*Preferences*/
-  create_item(menu,"Preferences", G_CALLBACK(cb_preferences));
+  create_item(menu,"Preferences...", G_CALLBACK(cb_preferences));
 
   /* Help */
   item=create_item(menu,"Help", NULL);


### PR DESCRIPTION
In the actual menu, the ellipsis does _not_ show up:
<img width="1154" height="962" alt="Screenshot_20251029_111834" src="https://github.com/user-attachments/assets/ac548994-648c-4556-a0fa-d95cae746606" />

And under the associated button in the header bar, `Preferences...` is not displayed at all. Only the `Set Preferences (Ctrl+P)` tooltip is shown. (OK, `Preferences...` is shown in the settings panel.)

This pull rerquest adds the ellipsis in the menu entry `Preferences...`:
<img width="1154" height="962" alt="Screenshot_20251029_112627" src="https://github.com/user-attachments/assets/84bc2c37-6885-45c0-8e8b-04fe29684f4a" />
