### PR TITLE
hintview: only require OpenGL 2.0 and GLSL 1.10

### DIFF
--- a/hintview/Linux/main.c
+++ b/hintview/Linux/main.c
@@ -396,7 +396,7 @@ static GdkGLContext* cb_create_context (GtkGLArea* self, gpointer user_data)
      c = gdk_window_create_gl_context (gdk_window,&error);
      if (c!=NULL)
        LOG("Has context\n");
-     gdk_gl_context_set_required_version (c,3,3);
+     gdk_gl_context_set_required_version (c,2,0);
  }
   LOG("Create Context\n");
  

--- a/hintview/Linux/renderOGL.c
+++ b/hintview/Linux/renderOGL.c
@@ -71,12 +71,12 @@ static uint32_t cur_fg=0; /*the current foreground color*/
 #define STR(X) QUOTE(X)
 #define QUOTE(X) #X
 static const char VertexShader[]=
-  "#version 330 core\n"
+  "#version 110\n"
   /* Input */
-  "layout(location = " STR(xyID) ") in vec2 vertexXY;\n"
-  "layout(location = " STR(uvID) ") in vec2 vertexUV;\n"
+  "attribute vec2 vertexXY;\n"
+  "attribute vec2 vertexUV;\n"
   /* output */
-   "out vec2 UV;\n"
+  "varying vec2 UV;\n"
   /* Constants for the current triangles */
   "uniform mat4 MVP;\n"
 
@@ -87,12 +87,10 @@ static const char VertexShader[]=
 
   
 static const char FragmentShader[]=
-  "#version 330 core\n"
+  "#version 110\n"
 
   /* Input */
-  "in vec2 UV;\n"
-  /* Output */
-  "out vec4 color;\n"
+  "varying vec2 UV;\n"
   /* Constants for the current triangles */
   "uniform sampler2D theTexture;\n"
   "uniform vec4 FGcolor;\n"
@@ -102,12 +100,12 @@ static const char FragmentShader[]=
   "void main()\n"
   "{ vec4 texColor = texture2D( theTexture, UV );\n"
     "if (IsImage==0) {\n"
-      "color.a = pow(texColor.r*FGcolor.a,Gamma);\n"
-      "color.r = FGcolor.r;\n"
-      "color.g = FGcolor.g;\n"
-      "color.b = FGcolor.b;\n"
+      "gl_FragColor.a = pow(texColor.r*FGcolor.a,Gamma);\n"
+      "gl_FragColor.r = FGcolor.r;\n"
+      "gl_FragColor.g = FGcolor.g;\n"
+      "gl_FragColor.b = FGcolor.b;\n"
     "}\n"
-    "else color = texColor;\n"
+    "else gl_FragColor = texColor;\n"
   "}\n"
 ;
 
@@ -164,6 +162,10 @@ static void createProgram(void)
   /* Create, linking, and check the program */
   ProgramID = glCreateProgram();
   if (ProgramID) {
+    glBindAttribLocation(ProgramID, xyID, "vertexXY");
+    checkGlError("vertexXY");
+    glBindAttribLocation(ProgramID, uvID, "vertexUV");
+    checkGlError("vertexUV");
     glAttachShader(ProgramID, vertexID);
     checkGlError("glAttachShader");
     glAttachShader(ProgramID, fragmentID);
@@ -466,6 +468,7 @@ void nativeImage(double x, double y, double w, double h, unsigned char *b, unsig
     glGenTextures(1, &ImageID);
     glBindTexture(GL_TEXTURE_2D, ImageID);
     checkGlError("glBindTexture ImageID");
+    glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
     glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0,
                  format, GL_UNSIGNED_BYTE, data);
     if (glGetError()!= GL_NO_ERROR)
@@ -473,8 +476,6 @@ void nativeImage(double x, double y, double w, double h, unsigned char *b, unsig
     		  format, GL_UNSIGNED_BYTE, data);
     checkGlError("glTexImage2D(image)");
     if (data!=grey) { stbi_image_free(data); data=NULL; }
-    glGenerateMipmap(GL_TEXTURE_2D);
-    checkGlError("glGenerateMipmap(image)");
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   }

--- a/hintview/minimal/main.c
+++ b/hintview/minimal/main.c
@@ -538,17 +538,13 @@ static int create_window(void)
   }
   glfwSetErrorCallback(error_callback);
   glfwWindowHint(GLFW_SAMPLES, 4);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE); // To make MacOS happy; should not be needed
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
   
   /* Open a window and create its OpenGL context */
   window = glfwCreateWindow( px_h, px_v, "HintView", NULL, NULL);
   if( window == NULL ){
-    hint_error("GLFW","Failed to open GLFW window.\n"
-	   "If you have an Intel GPU, they are not 3.3 compatible.\n"
-	   "Try the 2.1 version of the tutorials.\n" );
+    hint_error("GLFW","Failed to open GLFW window.\n");
     glfwTerminate();
     return 0;
   }

--- a/hintview/minimal/renderOGL.c
+++ b/hintview/minimal/renderOGL.c
@@ -71,12 +71,12 @@ static uint32_t cur_fg=0; /*the current foreground color*/
 #define STR(X) QUOTE(X)
 #define QUOTE(X) #X
 static const char VertexShader[]=
-  "#version 330 core\n"
+  "#version 110\n"
   /* Input */
-  "layout(location = " STR(xyID) ") in vec2 vertexXY;\n"
-  "layout(location = " STR(uvID) ") in vec2 vertexUV;\n"
+  "attribute vec2 vertexXY;\n"
+  "attribute vec2 vertexUV;\n"
   /* output */
-   "out vec2 UV;\n"
+  "varying vec2 UV;\n"
   /* Constants for the current triangles */
   "uniform mat4 MVP;\n"
 
@@ -87,12 +87,10 @@ static const char VertexShader[]=
 
   
 static const char FragmentShader[]=
-  "#version 330 core\n"
+  "#version 110\n"
 
   /* Input */
-  "in vec2 UV;\n"
-  /* Output */
-  "out vec4 color;\n"
+  "varying vec2 UV;\n"
   /* Constants for the current triangles */
   "uniform sampler2D theTexture;\n"
   "uniform vec4 FGcolor;\n"
@@ -102,12 +100,12 @@ static const char FragmentShader[]=
   "void main()\n"
   "{ vec4 texColor = texture2D( theTexture, UV );\n"
     "if (IsImage==0) {\n"
-      "color.a = pow(texColor.r*FGcolor.a,Gamma);\n"
-      "color.r = FGcolor.r;\n"
-      "color.g = FGcolor.g;\n"
-      "color.b = FGcolor.b;\n"
+      "gl_FragColor.a = pow(texColor.r*FGcolor.a,Gamma);\n"
+      "gl_FragColor.r = FGcolor.r;\n"
+      "gl_FragColor.g = FGcolor.g;\n"
+      "gl_FragColor.b = FGcolor.b;\n"
     "}\n"
-    "else color = texColor;\n"
+    "else gl_FragColor = texColor;\n"
   "}\n"
 ;
 
@@ -164,6 +162,10 @@ static void createProgram(void)
   /* Create, linking, and check the program */
   ProgramID = glCreateProgram();
   if (ProgramID) {
+    glBindAttribLocation(ProgramID, xyID, "vertexXY");
+    checkGlError("vertexXY");
+    glBindAttribLocation(ProgramID, uvID, "vertexUV");
+    checkGlError("vertexUV");
     glAttachShader(ProgramID, vertexID);
     checkGlError("glAttachShader");
     glAttachShader(ProgramID, fragmentID);
@@ -445,6 +447,7 @@ void nativeImage(double x, double y, double w, double h, unsigned char *b, unsig
     glGenTextures(1, &ImageID);
     glBindTexture(GL_TEXTURE_2D, ImageID);
     checkGlError("glBindTexture ImageID");
+    glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
     glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0,
                  format, GL_UNSIGNED_BYTE, data);
     if (glGetError()!= GL_NO_ERROR)
@@ -452,8 +455,6 @@ void nativeImage(double x, double y, double w, double h, unsigned char *b, unsig
     		  format, GL_UNSIGNED_BYTE, data);
     checkGlError("glTexImage2D(image)");
     if (data!=grey) { stbi_image_free(data); data=NULL; }
-    glGenerateMipmap(GL_TEXTURE_2D);
-    checkGlError("glGenerateMipmap(image)");
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   }


### PR DESCRIPTION
There's no use in requiring unnecessarily new versions and my own machine only supports OpenGL 2.1 and GLSL 1.20.  I haven't looked very hard, but as far as I can tell, nothing in here actually requires anything newer.  The shaders can use older syntax for the same things; mipmaps can be generated automatically.

I'm unable to test anything other than minimal and "Linux" right now, so I'm leaving them be.